### PR TITLE
Update map version

### DIFF
--- a/addons/sourcemod/scripting/VScript_ze_grey_world.sp
+++ b/addons/sourcemod/scripting/VScript_ze_grey_world.sp
@@ -53,7 +53,8 @@ public void OnMapStart()
 
 public void OnMapEnd()
 {
-	if (g_bValidMap) UnhookEvent("round_start", OnRoundStart, EventHookMode_PostNoCopy);
+	if (g_bValidMap)
+		UnhookEvent("round_start", OnRoundStart, EventHookMode_PostNoCopy);
 	g_bValidMap = false;
 }
 

--- a/addons/sourcemod/scripting/VScript_ze_grey_world.sp
+++ b/addons/sourcemod/scripting/VScript_ze_grey_world.sp
@@ -3,7 +3,7 @@
 
 #include <vscripts>
 
-#define MAP_NAME "ze_grey_world_css"
+#define MAP_NAME "ze_grey_world_css1"
 
 bool g_bValidMap = false;
 

--- a/addons/sourcemod/scripting/VScript_ze_grey_world.sp
+++ b/addons/sourcemod/scripting/VScript_ze_grey_world.sp
@@ -3,8 +3,6 @@
 
 #include <vscripts>
 
-#define MAP_NAME "ze_grey_world_css1"
-
 bool g_bValidMap = false;
 
 public Plugin myinfo =
@@ -39,7 +37,7 @@ public void OnMapStart()
 {
 	char sBuffer[256];
 	GetCurrentMap(sBuffer, sizeof(sBuffer));
-	g_bValidMap = (strcmp(sBuffer, MAP_NAME, false) == 0);
+	g_bValidMap = (strncmp(sBuffer, "ze_grey_world", 13) == 0);
 	if (g_bValidMap)
 	{
 		HookEvent("round_start", OnRoundStart, EventHookMode_PostNoCopy);


### PR DESCRIPTION
Mike Wazoski has released a new map version under the name `ze_grey_world_css1`. The plugin is currently hard-coded to the old version ending with `_css`. I've changed it so it only checks the name of the map and not version.